### PR TITLE
Support done to have exceptions surface

### DIFF
--- a/examples/require-config.js
+++ b/examples/require-config.js
@@ -4,7 +4,7 @@
 require.config({
   baseUrl: '..',
   paths: {
-    jquery: 'bower_components/jquery/jquery',
+    jquery: 'bower_components/jquery/dist/jquery',
     q: 'bower_components/q/q',
     rsvp: 'bower_components/rsvp/rsvp.amd',
 

--- a/requirejs-promise.js
+++ b/requirejs-promise.js
@@ -21,7 +21,7 @@ define(function () {
           result.fail(function () {
             load.error.apply(this, arguments);
           });
-          result.then(function () {
+          result.done(function () {
             load.apply(this, arguments);
           });
         } else {

--- a/requirejs-promise.js
+++ b/requirejs-promise.js
@@ -21,7 +21,10 @@ define(function () {
           result.fail(function () {
             load.error.apply(this, arguments);
           });
-          result.done(function () {
+          // If the promise supports "done" (not all do), we want to use that to
+          // terminate the promise chain and expose any exceptions.
+          var complete = result.done || result.then;
+          complete.call(result, function () {
             load.apply(this, arguments);
           });
         } else {


### PR DESCRIPTION
Here's another go. Copying the text from the earlier pull request. Also changed location of jQuery to get tests to pass.

Since we're "leaving the promise world", we should terminate the continuation chain with a done function. Otherwise exceptions from the AMD module that requires the promise module won't be visible.

Example:

``` javascript
define('promiseModule', function() {
   return Q({});
})

define(function(require) {
  var result = require('promiseModule');
  result.DoSomethingWeird(); // This exception will be hidden since it's "inside" a promise chain
})
```
